### PR TITLE
Solve issues related to whitespaces in the path of windows filepath.

### DIFF
--- a/s2aio/__main__.py
+++ b/s2aio/__main__.py
@@ -123,7 +123,7 @@ class S2AIO:
 
         self.windows_wait_time = int(config.get('scratch_info', 'windows_wait_time'))
 
-        self.scratch_project = self.base_path + '/ScratchFiles/ScratchProjects/' + scratch_block_language_dict[language]
+        self.scratch_project = '"' + self.base_path + '"' + '/ScratchFiles/ScratchProjects/' + scratch_block_language_dict[language]
 
         self.client = client
 


### PR DESCRIPTION
This is to fix the issue regarding :
[https://github.com/MrYsLab/s2aio/issues/27](url)
Tested in both situations - scratch file opened

